### PR TITLE
feat: remove the accessToken generated when logging out

### DIFF
--- a/src/features/VercelManager.ts
+++ b/src/features/VercelManager.ts
@@ -73,6 +73,7 @@ export class VercelManager {
    * Un-sets authentication and project and calls didLogOut, didDeploymentsUpdated, and didEnvironmentsUpdates;
    */
   async logOut() {
+    await this.api.deleteAccessToken({ tokenId: "current" }, undefined);
     await this.token.setAuth(undefined);
     await this.token.setProject(undefined);
     this.onDidLogOut();

--- a/src/features/models.ts
+++ b/src/features/models.ts
@@ -116,6 +116,7 @@ export namespace VercelResponse {
       message: string;
     };
   };
+  export type deleteAuthToken = { tokenId: string };
   export namespace oauth {
     export type accessToken = {
       token_type: "Bearer";

--- a/src/utils/Api.ts
+++ b/src/utils/Api.ts
@@ -271,6 +271,19 @@ export class Api {
       },
     }),
   };
+  public deleteAccessToken = this.init<
+    VercelResponse.deleteAuthToken,
+    {
+      /** Use special value 'current' to delete the current access token */
+      tokenId: "current" | (string & Record<never, never>);
+      teamId?: string;
+    }
+  >({
+    path: "/v3/user/tokens/:tokenId",
+    fetch: {
+      method: "DELETE",
+    },
+  });
   public oauth = {
     accessToken: this.init<
       VercelResponse.oauth.accessToken,


### PR DESCRIPTION
This means it can no longer be a security flaw if it is leaked. Additionally, keeps auth keys from piling up.
